### PR TITLE
Removed redundant manage.py and changed default Django settings to qworkerd.settings

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,7 +2,10 @@
 import os
 import sys
 
-if __name__ == "__main__":
-  os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
+def main ():
+  os.environ.setdefault ("DJANGO_SETTINGS_MODULE", "qworkerd.settings")
   from django.core.management import execute_from_command_line
-  execute_from_command_line(sys.argv)
+  execute_from_command_line (sys.argv)
+
+if __name__ == "__main__":
+  main ()

--- a/qworkerd/_cfgtool/qworkerd.conf.templ
+++ b/qworkerd/_cfgtool/qworkerd.conf.templ
@@ -3,7 +3,7 @@
 # Where is RabbitMQ?
 BROKER_URL = "${qworkerd.broker_url}"
 
-# The backend used to store task results (tombstones). 
+# The backend used to store task results (tombstones).
 # CELERY_RESULT_BACKEND = "db+mysql://root:root@localhost/qeventlog"
 # CELERY_RESULT_BACKEND = "cache+memcached://127.0.0.1:11211/"
 CELERY_RESULT_BACKEND = "${qworkerd.result_backend}"
@@ -13,7 +13,7 @@ SECRET_KEY = "${qworkerd.secret_key}"
 
 # Entry for logging exceptions to Sentry
 RAVEN_CONFIG = {
-  "dsn": "sync+${qworkerd.sentry_dsn}",
+  "dsn": "${qworkerd.sentry_dsn}",
 }
 
 # Number of simultaneous jobs to run on the worker

--- a/qworkerd/qworkerd_manage.py
+++ b/qworkerd/qworkerd_manage.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-import os
-import sys
-
-if __name__ == "__main__":
-  os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
-  from django.core.management import execute_from_command_line
-  execute_from_command_line(sys.argv)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import glob, versioneer
 
 setup (
     name = "qworkerd",
-    version = versioneer.get_version (),                
+    version = versioneer.get_version (),
     description = "Celery based worker (default/pluggable)",
     long_description = file ("README.rst").read (),
     cmdclass = versioneer.get_cmdclass (),
@@ -29,13 +29,13 @@ setup (
     data_files = [
         ("/etc/cfgtool/module.d/", ["qworkerd/_cfgtool/qworkerd",]),
         ("/etc/qworkerd", glob.glob ("qworkerd/_cfgtool/*.templ")),
-        ("./bin", ["qworkerd/qworkerd_manage.py"]),
     ],
     zip_safe = False,
     install_requires = [line.strip ()
                         for line in file ("requirements.txt").readlines ()],
     entry_points = {
         "console_scripts": [
+          "qworkerd_manage = manage:main"
         ],
     },
 )


### PR DESCRIPTION
`manage.py` can now be called from anywhere for a `qworkerd` plugin using `qworkerd_manage`.
