### PR TITLE
Added the manage.py file to the manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include LICENSE
 include README.rst
 include requirements.txt
 include versioneer.py
+include manage.py
 include qworkerd/_version.py


### PR DESCRIPTION
The `qworkerd_manage` command fails without this. Kind of a big deal.
